### PR TITLE
Fixed some stuff

### DIFF
--- a/Software/REST HTTP Server/http/switch.lua
+++ b/Software/REST HTTP Server/http/switch.lua
@@ -1,12 +1,13 @@
 return function (connection, req, args)
   dofile("httpserver-header.lc")(connection, 200, 'xml')
-  connection:send("<dimmer>"..dim.."</dimmer>")
   
   if (args ~= nil) and (args.state ~= nil)
   then
     dim = tonumber(args.state)
 	print("Set dimmer to " .. dim)
   end
+  
+  connection:send("<dimmer>"..dim.."</dimmer>")
   
   gpio.mode(1,gpio.OUTPUT)
   if (dim==0)

--- a/Software/REST HTTP Server/init.lua
+++ b/Software/REST HTTP Server/init.lua
@@ -17,8 +17,8 @@ wifiConfig.accessPointIpConfig.netmask = "255.255.255.0"
 wifiConfig.accessPointIpConfig.gateway = "192.168.111.1"
 
 wifiConfig.stationPointConfig = {}
-wifiConfig.stationPointConfig.ssid = "Eagles"               -- Name of the WiFi network you want to join
-wifiConfig.stationPointConfig.pwd =  "E7D9F48032"           -- Password for the WiFi network
+wifiConfig.stationPointConfig.ssid = "HomeAutoWifi"-- Eagles               -- Name of the WiFi network you want to join
+wifiConfig.stationPointConfig.pwd =  "BrandonHomeAuto"--E7D9F48032            -- Password for the WiFi network
 
 -- Tell the chip to connect to the access point
 
@@ -80,7 +80,7 @@ collectgarbage()
 
 if (wifi.getmode() == wifi.STATION) or (wifi.getmode() == wifi.STATIONAP) then
     local joinCounter = 0
-    local joinMaxAttempts = 5
+    local joinMaxAttempts = 50
     tmr.alarm(0, 3000, 1, function()
        local ip = wifi.sta.getip()
        if ip == nil and joinCounter < joinMaxAttempts then
@@ -96,10 +96,13 @@ if (wifi.getmode() == wifi.STATION) or (wifi.getmode() == wifi.STATIONAP) then
           joinCounter = nil
           joinMaxAttempts = nil
           collectgarbage()
+		  run()
        end
     end)
 end
 
+
+run=function()
 -- Uncomment to automatically start the server in port 80
 if (not not wifi.sta.getip()) or (not not wifi.ap.getip()) then
 	print("Starting Server!!!!")
@@ -108,4 +111,4 @@ if (not not wifi.sta.getip()) or (not not wifi.ap.getip()) then
 	dofile("TrueTRIAC.lc")
 	print("dofile('httpserver.lc')(80)")
 end
-
+end


### PR DESCRIPTION
It appears that the UPNP service is not compatible with the TrendNet
router - so this now uses a linksys router.
Auto-run on boot now works, AP must be connected in the first ~1 minute,
otherwise a reboot is required.

Todo: make it so that reboots are not required.